### PR TITLE
Allows use of single database connection

### DIFF
--- a/admin/classes/common/DatabaseObject.php
+++ b/admin/classes/common/DatabaseObject.php
@@ -44,7 +44,10 @@ class DatabaseObject extends DynamicObject {
 		$this->primaryKeyName = $arguments->primaryKeyName;
 
 		$this->primaryKey = $arguments->primaryKey;
-		$this->db = new DBService;
+
+        $arguments->setDefaultValueForArgumentName('db',false);
+        $this->db = $arguments->db ? $arguments->db : new DBService;
+        
 		$this->defineAttributes();
 		$this->overridePrimaryKeyName();
 		$this->load();

--- a/admin/classes/domain/Platform.php
+++ b/admin/classes/domain/Platform.php
@@ -359,8 +359,9 @@ class Platform extends DatabaseObject {
 			$object = new PublisherPlatform(new NamedArguments(array('primaryKey' => $result['publisherPlatformID'])));
 			array_push($objects, $object);
 		}else{
+            $db = new DBService;
 			foreach ($result as $row) {
-				$object = new PublisherPlatform(new NamedArguments(array('primaryKey' => $row['publisherPlatformID'])));
+				$object = new PublisherPlatform(new NamedArguments(array('primaryKey' => $row['publisherPlatformID'],'db'=>$db)));
 				array_push($objects, $object);
 			}
 		}


### PR DESCRIPTION
This is a quick fix I made for an issue I had while attempting to retrieve logins for a platform. The ajax request would fail, leaving the browser "processing" indefinitely. I looked at the logs and found that php was failing because of too many concurrent mysql connections, although no limit was set in php.ini. Looking into the code, I found that the script failed while populating a list of organizations. This list became long, and each organization was given its own concurrently open database connection. 
To solve this problem, I added an optional input parameter for DatabaseObject classes which allows them to use an existing database connection instead of creating a new one. Then I told the login ajax script to use a single database connection for each organization in the list. Let me know if you see any problems with this solution.