### PR TITLE
extra check to avoid "notice" level error.

### DIFF
--- a/user.php
+++ b/user.php
@@ -78,9 +78,11 @@ if ($config->settings->authModule == 'Y'){
 		$remoteAuth=eval("return \$$theVarStem;");
 
 		//use the split in case the remote login is supplied as an email address
-		list ($loginID,$restofAddr) = explode("@", $remoteAuth);
-
-
+		if (strpos($remoteAuth,'@') !== false) {
+		  list ($loginID,$restofAddr) = explode("@", $remoteAuth);
+		} else {
+		  $loginID = $remoteAuth;
+		}
 
 		session_start();
 		$_SESSION['loginID'] = $loginID;


### PR DESCRIPTION
To avoid a "Notice" level error, I've added a check to see if $remoteAuth is an email.